### PR TITLE
fixed reference to delta in scroll event

### DIFF
--- a/bokehjs/src/coffee/core/bokeh_events.ts
+++ b/bokehjs/src/coffee/core/bokeh_events.ts
@@ -159,7 +159,7 @@ export class MouseWheel extends PointEvent {
     return new this({
       sx: e.bokeh['sx'],
       sy: e.bokeh['sy'],
-      delta: e.delta,
+      delta: e.bokeh['delta'],
       model_id: model_id,
     })
   }


### PR DESCRIPTION
I came across a bug in the MouseWheel event. The bug can be shown by running this app from the howto section:
bokeh/examples/howto/events_app.py

The value for "delta" of the scroll event was showing up as NaN / None in both js_on_event and on_event callbacks.

Without fully understanding how everything's connected, I was able to trace the problem to line 162 of bokeh/bokehjs/src/coffee/core/bokeh_events.ts

Changing 
```js
static from_event(e: any, model_id: string = null) {
    return new this({
      sx: e.bokeh['sx'],
      sy: e.bokeh['sy'],
      delta: e.delta,
      model_id: model_id,
    })
  }
```
to 
```js
  static from_event(e: any, model_id: string = null) {
    return new this({
      sx: e.bokeh['sx'],
      sy: e.bokeh['sy'],
      delta: e.bokeh['delta'],
      model_id: model_id,
    })
  }
```
fixes the problem, and allows the delta parameter to pass through.

- [x] issues: fixes #6238
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
